### PR TITLE
Add integration package to MockHttp

### DIFF
--- a/AutoFixtureExtensions.sln
+++ b/AutoFixtureExtensions.sln
@@ -3,6 +3,14 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0FF25712-4D64-4381-9F67-3A63B1A5CFD4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockHttp", "src\MockHttp\MockHttp.csproj", "{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0353C3F4-A9CA-4A2B-9DFE-DDBBCA3B863C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.MockHttp", "tests\Tests.MockHttp\Tests.MockHttp.csproj", "{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,5 +22,35 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Debug|x64.Build.0 = Debug|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Debug|x86.Build.0 = Debug|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Release|x64.ActiveCfg = Release|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Release|x64.Build.0 = Release|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Release|x86.ActiveCfg = Release|Any CPU
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2}.Release|x86.Build.0 = Release|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Debug|x64.Build.0 = Debug|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Debug|x86.Build.0 = Debug|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Release|x64.ActiveCfg = Release|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Release|x64.Build.0 = Release|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Release|x86.ActiveCfg = Release|Any CPU
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C6372AF3-1787-4EE8-81D3-96C86AD9B9A2} = {0FF25712-4D64-4381-9F67-3A63B1A5CFD4}
+		{1FCA3A3E-8C43-495F-8CE3-5672E5D3D047} = {0353C3F4-A9CA-4A2B-9DFE-DDBBCA3B863C}
 	EndGlobalSection
 EndGlobal

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,4 @@
+# AutoFixture Extensions contributors (sorted alphabetically)
+
+* **[Andrei Ivascu](https://github.com/aivascu)**
+  * Integration with MockHttp

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # AutoFixture Extensions
 This repository contains a set of small extension packages to make the life of AutoFixture users easier.
+
+## Packages
+The following packages are available:
+
+* **[Kralizek.AutoFixture.Extensions.MockHttp](./tree/master/src/MockHttp)**<br/>
+  An integration between AutoFixture and [MockHttp](https://github.com/richardszalay/mockhttp) to make HTTP testing easier.
+
+## License
+The content of this repository is licensed under the [MIT license](https://github.com/Kralizek/AutoFixtureExtensions/blob/master/LICENSE.txt).

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,30 @@
+
+<Project>
+  <PropertyGroup>
+    <RootNamespace>AutoFixture</RootNamespace>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Renato Golia</Authors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Kralizek/AutoFixtureExtensions</PackageProjectUrl>
+    <NoWarn>NU5105,NU5125,NU5048</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" /> 
+  </ItemGroup>
+</Project>

--- a/src/MockHttp/Extensions/HttpClientRequestSpecification.cs
+++ b/src/MockHttp/Extensions/HttpClientRequestSpecification.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Net.Http;
+using AutoFixture.Kernel;
+
+namespace AutoFixture.Extensions
+{
+    public class HttpClientRequestSpecification : IRequestSpecification
+    {
+        public bool IsSatisfiedBy(object request)
+        {
+            return request is Type type && type == typeof(HttpClient);
+        }
+    }
+}

--- a/src/MockHttp/Extensions/HttpClientSpecimenBuilder.cs
+++ b/src/MockHttp/Extensions/HttpClientSpecimenBuilder.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using AutoFixture.Kernel;
+using RichardSzalay.MockHttp;
+
+namespace AutoFixture.Extensions
+{
+    public class HttpClientSpecimenBuilder : ISpecimenBuilder
+    {
+        public HttpClientSpecimenBuilder(IRequestSpecification requestSpecification)
+        {
+            RequestSpecification = requestSpecification ?? throw new ArgumentNullException(nameof(requestSpecification));
+        }
+
+        public HttpClientSpecimenBuilder() : this(new HttpClientRequestSpecification()) { }
+
+        public IRequestSpecification RequestSpecification { get; }
+
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!RequestSpecification.IsSatisfiedBy(request))
+            {
+                return new NoSpecimen();
+            }
+
+            var handler = context.Create<MockHttpMessageHandler>();
+
+            return handler.ToHttpClient();
+        }
+    }
+}

--- a/src/MockHttp/FixtureExtensions.cs
+++ b/src/MockHttp/FixtureExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using AutoFixture.Extensions;
+
+namespace AutoFixture
+{
+    public static class FixtureExtensions
+    {
+        public static IFixture AddMockHttp(this IFixture fixture)
+        {
+            if (fixture == null)
+            {
+                throw new ArgumentNullException(nameof(fixture));
+            }
+
+            fixture.Customizations.Add(new HttpClientSpecimenBuilder());
+
+            return fixture;
+        }
+    }
+}

--- a/src/MockHttp/MockHttp.csproj
+++ b/src/MockHttp/MockHttp.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Renato Golia;Andrei Ivascu</Authors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Kralizek.AutoFixture.Extensions.MockHttp</PackageId>
+    <PackageTags>autofixture;unit testing;test;mock;httpClient;mockhttp</PackageTags>
+    <Description>An extension to AutoFixture to easily work with MockHttp.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/MockHttp/README.md
+++ b/src/MockHttp/README.md
@@ -1,0 +1,46 @@
+# Kralizek.AutoFixture.Extensions.MockHttp
+This package is meant to provide an easy integration between [AutoFixture](https://github.com/AutoFixture/AutoFixture) and [MockHttp](https://github.com/richardszalay/mockhttp).
+
+## Usage
+You can use this extension by simply invoking the `AddMockHttp` method on the `IFixture` instance at hand.
+
+```csharp
+var fixture = new Fixture().AddMockHttp();
+
+var testUri = fixture.Create<Uri>();
+var expectedResult = fixture.Create<string>();
+
+var handler = fixture.Freeze<MockHttpMessageHandler>();
+handler.When(HttpMethod.Get, testUri.ToString()).Respond(HttpStatusCode.OK, new StringContent(expectedResult));
+
+var sut = fixture.Create<TestService>();
+
+var result = await sut.GetString(testUri);
+
+Assert.That(result, Is.EqualTo(expectedResult));            
+```
+
+Alternatively, you can use a customized version of the `AutoData` attribute to improve the readibility of your unit test.
+
+```csharp
+[AttributeUsage(AttributeTargets.Method)]
+public class TestAutoDataAttribute : AutoDataAttribute
+{
+    public TestAutoDataAttribute() : base (() => new Fixture().AddMockHttp()) { }
+}
+
+[Test, TestAutoData]
+public async Task Custom_AutoData_should_work([Frozen] MockHttpMessageHandler handler, TestService sut, Uri testUri, string expectedResult)
+{
+    handler.When(HttpMethod.Get, testUri.ToString()).Respond(HttpStatusCode.OK, new StringContent(expectedResult));
+
+    var result = await sut.GetString(testUri);
+
+    Assert.That(result, Is.EqualTo(expectedResult));
+}
+```
+
+## Credits
+The code in this package was provided by [Andrei Ivascu](https://github.com/aivascu).
+* Source: https://gist.github.com/aivascu/97a9459726bc650c8c1a4b0d6ec44ce9
+* Reference: https://github.com/AutoFixture/AutoFixture/issues/1152

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,14 @@
+<Project>
+  <PropertyGroup>
+    <RootNamespace>Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.NUnit3" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.Idioms" Version="4.11.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Tests.MockHttp/CustomAutoDataAttribute.cs
+++ b/tests/Tests.MockHttp/CustomAutoDataAttribute.cs
@@ -1,0 +1,29 @@
+using AutoFixture;
+using System;
+using AutoFixture.NUnit3;
+using AutoFixture.AutoMoq;
+
+namespace Tests
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class CustomAutoDataAttribute : AutoDataAttribute
+    {
+        public CustomAutoDataAttribute() : base(CreateFixture)
+        {
+
+        }
+
+        private static IFixture CreateFixture()
+        {
+            var fixture = new Fixture();
+
+            fixture.Customize(new AutoMoqCustomization
+            {
+                GenerateDelegates = true,
+                ConfigureMembers = true
+            });
+
+            return fixture;
+        }
+    }
+}

--- a/tests/Tests.MockHttp/Extensions/HttpClientRequestSpecificationTests.cs
+++ b/tests/Tests.MockHttp/Extensions/HttpClientRequestSpecificationTests.cs
@@ -1,0 +1,34 @@
+using System.Net.Http;
+using AutoFixture.Extensions;
+using NUnit.Framework;
+
+namespace Tests.Extensions
+{
+    [TestFixture]
+    public class HttpClientRequestSpecificationTests
+    {
+        [Test, CustomAutoData]
+        public void IsSatisfiedBy_returns_true_if_request_is_HttpClient(HttpClientRequestSpecification sut)
+        {
+            var result = sut.IsSatisfiedBy(typeof(HttpClient));
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test, CustomAutoData]
+        public void IsSatisfiedBy_returns_false_if_request_is_null(HttpClientRequestSpecification sut)
+        {
+            var result = sut.IsSatisfiedBy(null);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test, CustomAutoData]
+        public void IsSatisfiedBy_returns_false_if_request_is_not_HttpClient(HttpClientRequestSpecification sut)
+        {
+            var result = sut.IsSatisfiedBy(typeof(object));
+
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/tests/Tests.MockHttp/Extensions/HttpClientSpecimenBuilderTests.cs
+++ b/tests/Tests.MockHttp/Extensions/HttpClientSpecimenBuilderTests.cs
@@ -1,0 +1,56 @@
+using System.Net.Http;
+using AutoFixture.Extensions;
+using AutoFixture.Idioms;
+using AutoFixture.Kernel;
+using NUnit.Framework;
+
+namespace Tests.Extensions
+{
+    [TestFixture]
+    public class HttpClientSpecimenBuilderTests
+    {
+        [Test, CustomAutoData]
+        public void Constructor_is_guarded(GuardClauseAssertion assertion)
+        {
+            assertion.Verify(typeof(HttpClientSpecimenBuilder).GetConstructors());
+        }
+
+        [Test, CustomAutoData]
+        public void RequestSpecification_exposes_passed_specification(IRequestSpecification requestSpecification)
+        {
+            var sut = new HttpClientSpecimenBuilder(requestSpecification);
+
+            Assert.That(sut.RequestSpecification, Is.SameAs(requestSpecification));
+        }
+
+        [Test, CustomAutoData]
+        public void Default_RequestSpecification_is_HttpClientRequestSpecification()
+        {
+            var sut = new HttpClientSpecimenBuilder();
+
+            Assert.That(sut.RequestSpecification, Is.InstanceOf<HttpClientRequestSpecification>());
+        }
+
+        [Test, CustomAutoData]
+        public void Create_is_guarded(GuardClauseAssertion assertion)
+        {
+            assertion.Verify(typeof(HttpClientSpecimenBuilder).GetMethod(nameof(HttpClientSpecimenBuilder.Create)));
+        }
+
+        [Test, CustomAutoData]
+        public void Create_returns_HttpClient_if_requested(HttpClientSpecimenBuilder sut, SpecimenContext context)
+        {
+            var result = sut.Create(typeof(HttpClient), context);
+
+            Assert.That(result, Is.InstanceOf<HttpClient>());
+        }
+
+        [Test, CustomAutoData]
+        public void Create_returns_NoSpecimen_if_request_is_invalid(HttpClientSpecimenBuilder sut, SpecimenContext context)
+        {
+            var result = sut.Create(typeof(object), context);
+
+            Assert.That(result, Is.InstanceOf<NoSpecimen>());
+        }
+    }
+}

--- a/tests/Tests.MockHttp/FixtureExtensionsTests.cs
+++ b/tests/Tests.MockHttp/FixtureExtensionsTests.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using AutoFixture;
+using System;
+using AutoFixture.Extensions;
+
+namespace Tests
+{
+    [TestFixture]
+    public class FixtureExtensionsTests
+    {
+        [Test]
+        public void AddMockHttp_throws_if_fixture_is_null()
+        {
+            IFixture fixture = null;
+            
+            Assert.Throws<ArgumentNullException>(() => fixture.AddMockHttp());    
+        }
+
+        [Test, CustomAutoData]
+        public void AddMockHttp_returns_same_fixture(IFixture fixture)
+        {
+            var result = fixture.AddMockHttp();
+
+            Assert.That(result, Is.SameAs(fixture));
+        }
+
+        [Test, CustomAutoData]
+        public void AddMockHttp_adds_HttpClientSpecimenBuilder_to_fixture_Customizations(IFixture fixture)
+        {
+            fixture.AddMockHttp();
+
+            Assert.That(fixture.Customizations, Has.One.InstanceOf<HttpClientSpecimenBuilder>());
+        }
+    }
+}

--- a/tests/Tests.MockHttp/Integration/IntegrationTests.cs
+++ b/tests/Tests.MockHttp/Integration/IntegrationTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.NUnit3;
+using NUnit.Framework;
+using RichardSzalay.MockHttp;
+
+namespace Tests.Integration
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class TestAutoDataAttribute : AutoDataAttribute
+    {
+        public TestAutoDataAttribute() : base (() => new Fixture().AddMockHttp()) { }
+    }
+
+    [TestFixture]
+    public class IntegrationTests
+    {
+        [Test]
+        public async Task No_AutoData_should_work()
+        {
+            var fixture = new Fixture().AddMockHttp();
+
+            var testUri = fixture.Create<Uri>();
+
+            var expectedResult = fixture.Create<string>();
+
+            var handler = fixture.Freeze<MockHttpMessageHandler>();
+
+            handler.When(HttpMethod.Get, testUri.ToString()).Respond(HttpStatusCode.OK, new StringContent(expectedResult));
+
+            var sut = fixture.Create<TestService>();
+
+            var result = await sut.GetString(testUri);
+
+            Assert.That(result, Is.EqualTo(expectedResult));            
+        }
+
+        [Test, AutoData]
+        public async Task Basic_AutoData_should_work(Fixture fixture, Uri testUri, string expectedResult)
+        {
+            fixture.AddMockHttp();
+
+            var handler = fixture.Freeze<MockHttpMessageHandler>();
+
+            handler.When(HttpMethod.Get, testUri.ToString()).Respond(HttpStatusCode.OK, new StringContent(expectedResult));
+
+            var sut = fixture.Create<TestService>();
+
+            var result = await sut.GetString(testUri);
+
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
+
+        [Test, TestAutoData]
+        public async Task Custom_AutoData_should_work([Frozen] MockHttpMessageHandler handler, TestService sut, Uri testUri, string expectedResult)
+        {
+            handler.When(HttpMethod.Get, testUri.ToString()).Respond(HttpStatusCode.OK, new StringContent(expectedResult));
+
+            var result = await sut.GetString(testUri);
+
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
+    }
+}

--- a/tests/Tests.MockHttp/Integration/TestService.cs
+++ b/tests/Tests.MockHttp/Integration/TestService.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Tests.Integration
+{
+    public interface IService
+    {
+        Task<string> GetString(Uri uri);
+    }
+
+    public class TestService : IService
+    {
+        private readonly HttpClient _http;
+
+        public TestService (HttpClient http)
+        {
+            _http = http ?? throw new ArgumentNullException(nameof(http));
+        }
+
+        public Task<string> GetString(Uri uri)
+        {
+            return _http.GetStringAsync(uri);
+        }
+    }}

--- a/tests/Tests.MockHttp/Tests.MockHttp.csproj
+++ b/tests/Tests.MockHttp/Tests.MockHttp.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net48</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MockHttp\MockHttp.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
By adding the content of this package, the user should be able to extend AutoFixture with a convenience extension method:

```csharp
fixture.AddMockHttp();
```

Note: the repository has no CI/CD pipeline yet, so no package will be produced after merging this PR.